### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov
 .idea
 *.iml
 *.komodoproject
+.vscode
 
 # Complexity
 output/*.html

--- a/ci/templates/tox.ini
+++ b/ci/templates/tox.ini
@@ -40,7 +40,7 @@ deps =
     isort
 skip_install = true
 commands =
-    python setup.py check --strict --metadata --restructuredtext
+    python setup.py check --strict-markers --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
     isort --verbose --check-only --diff --recursive src tests setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ python_files =
 
 addopts =
     -ra
-    --strict
+    --strict-markers
     --ignore=docs/conf.py
     --ignore=setup.py
     --ignore=ci

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -28,7 +28,7 @@ from oemof.network.network import Node
 
 
 class TestsEnergySystem:
-    def setup(self):
+    def setup_method(self):
         self.es = es.EnergySystem()
 
     def test_entity_grouping_on_construction(self):

--- a/tests/test_groupings.py
+++ b/tests/test_groupings.py
@@ -24,7 +24,9 @@ def test_initialization_argument_checks():
     with pytest.raises(TypeError, match=message):
         Grouping()
 
-    message = "Grouping arguments `key` and `constant_key` are  mutually exclusive."
+    message = (
+        "Grouping arguments `key` and `constant_key` are  mutually exclusive."
+    )
     with pytest.raises(TypeError, match=message):
         Grouping(key=lambda x: x, constant_key="key")
 

--- a/tests/test_groupings.py
+++ b/tests/test_groupings.py
@@ -54,10 +54,8 @@ def test_mutable_mapping_groups():
     groups = {}
     expected = {3: {"o": 2, "f": 1}}
     g("foo", groups)
-    eq_(
-        groups,
-        expected,
-        "\n  Expected: {} \n  Got     : {}".format(expected, groups),
+    assert groups == expected, (
+        "\n  Expected: {} \n  Got     : {}".format(expected, groups)
     )
 
 
@@ -69,8 +67,6 @@ def test_immutable_mapping_groups():
     groups = {}
     expected = {3: MaProTy({"o": 2, "f": 1})}
     g("foo", groups)
-    eq_(
-        groups,
-        expected,
-        "\n  Expected: {} \n  Got     : {}".format(expected, groups),
+    assert groups == expected, (
+        "\n  Expected: {} \n  Got     : {}".format(expected, groups)
     )

--- a/tests/test_groupings.py
+++ b/tests/test_groupings.py
@@ -12,8 +12,7 @@ SPDX-License-Identifier: MIT
 
 from types import MappingProxyType as MaProTy
 
-from nose.tools import assert_raises
-from nose.tools import eq_
+import pytest
 
 from oemof.network.groupings import Grouping
 
@@ -21,26 +20,26 @@ from oemof.network.groupings import Grouping
 def test_initialization_argument_checks():
     """`Grouping` constructor should raise `TypeError` on bad arguments."""
 
-    message = "\n`Grouping` constructor did not check mandatory arguments."
-    with assert_raises(TypeError, msg=message):
+    message = "Grouping constructor missing required argument"
+    with pytest.raises(TypeError, match=message):
         Grouping()
 
-    message = "\n`Grouping` constructor did not check conflicting arguments."
-    with assert_raises(TypeError, msg=message):
+    message = "Grouping arguments `key` and `constant_key` are  mutually exclusive."
+    with pytest.raises(TypeError, match=message):
         Grouping(key=lambda x: x, constant_key="key")
 
 
 def test_notimplementederrors():
     """`Grouping` should raise an error when reaching unreachable code."""
 
-    message = "\n`Grouping.key` not overriden, but no error raised."
-    with assert_raises(NotImplementedError, msg=message):
+    message = "There is no default implementation for `Groupings.key`."
+    with pytest.raises(NotImplementedError, match=message):
         g = Grouping(key="key")
         del g.key
         g.key("dummy argument")
 
-    message = "\n`Grouping.filter` not overriden, but no error raised."
-    with assert_raises(NotImplementedError, msg=message):
+    message = "`Groupings.filter` called without being overridden."
+    with pytest.raises(NotImplementedError, match=message):
         g = Grouping(key="key")
         del g.filter
         g.filter("dummy argument")
@@ -54,8 +53,8 @@ def test_mutable_mapping_groups():
     groups = {}
     expected = {3: {"o": 2, "f": 1}}
     g("foo", groups)
-    assert groups == expected, (
-        "\n  Expected: {} \n  Got     : {}".format(expected, groups)
+    assert groups == expected, "\n  Expected: {} \n  Got     : {}".format(
+        expected, groups
     )
 
 
@@ -67,6 +66,6 @@ def test_immutable_mapping_groups():
     groups = {}
     expected = {3: MaProTy({"o": 2, "f": 1})}
     g("foo", groups)
-    assert groups == expected, (
-        "\n  Expected: {} \n  Got     : {}".format(expected, groups)
+    assert groups == expected, "\n  Expected: {} \n  Got     : {}".format(
+        expected, groups
     )

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -28,7 +28,7 @@ from oemof.network.network import Transformer
 
 
 class TestsNode:
-    def setup(self):
+    def setup_method(self):
         self.energysystem = EnSys()
 
     def test_that_attributes_cannot_be_added(self):
@@ -268,7 +268,7 @@ class TestsNode:
 
 
 class TestsEdge:
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_edge_construction_side_effects(self):
@@ -329,7 +329,7 @@ class TestsEdge:
 
 
 class TestsEnergySystemNodesIntegration:
-    def setup(self):
+    def setup_method(self):
         self.es = EnSys()
 
     def test_entity_registration(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,19 +3,17 @@ envlist =
     clean,
     check,
     docs,
-    py37-cover,
-    py37-nocov,
-    py38-cover,
-    py38-nocov,
-    py39-cover,
-    py39-nocov,
+    py38,
+    py39,
+    py310,
+    py3-nocov,
     report
 
 [gh-actions]
 python =
-    3.7: py37-cover
-    3.8: py38-cover
-    3.9: py39-cover
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 basepython =
@@ -29,9 +27,10 @@ passenv =
 deps =
     nose
     pytest
-    pytest-travis-fold
 commands =
     {posargs:pytest -vv --ignore=src}
+
+ignore_basepython_conflict = True
 
 [testenv:bootstrap]
 deps =
@@ -55,7 +54,7 @@ commands =
     twine check dist/oemof*
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff src tests setup.py
+    isort --check-only --profile black --diff src tests setup.py
 
 
 [testenv:docs]
@@ -73,7 +72,12 @@ skip_install = true
 commands =
     coveralls []
 
-
+[testenv:codecov]
+deps =
+    codecov
+skip_install = true
+commands =
+    codecov []
 
 [testenv:report]
 deps = coverage
@@ -87,8 +91,8 @@ commands = coverage erase
 skip_install = true
 deps = coverage
 
-[testenv:py37-cover]
-basepython = {env:TOXPYTHON:python3.7}
+[testenv:py310]
+basepython = {env:TOXPYTHON:python3.10}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -98,10 +102,7 @@ deps =
     {[testenv]deps}
     pytest-cov
 
-[testenv:py37-nocov]
-basepython = {env:TOXPYTHON:python3.7}
-
-[testenv:py38-cover]
+[testenv:py38]
 basepython = {env:TOXPYTHON:python3.8}
 setenv =
     {[testenv]setenv}
@@ -112,10 +113,7 @@ deps =
     {[testenv]deps}
     pytest-cov
 
-[testenv:py38-nocov]
-basepython = {env:TOXPYTHON:python3.8}
-
-[testenv:py39-cover]
+[testenv:py39]
 basepython = {env:TOXPYTHON:python3.9}
 setenv =
     {[testenv]setenv}
@@ -126,5 +124,5 @@ deps =
     {[testenv]deps}
     pytest-cov
 
-[testenv:py39-nocov]
-basepython = {env:TOXPYTHON:python3.9}
+[testenv:py3-nocov]
+basepython = {env:TOXPYTHON:python3}


### PR DESCRIPTION
Unit tests did not run because of an outdated tox configuration. This PR fixes that. Secondly, use of the deprecated library "nose" is removed so that we will not run into the same problem very soon again.

* [x] Fix running tests (also at GitHub)
* [x] Replace nose