### PR TITLE
Move Node functionality from Entity to Node

### DIFF
--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -14,10 +14,6 @@ SPDX-License-Identifier: MIT
 
 from functools import total_ordering
 
-from .helpers import Inputs
-from .helpers import Outputs
-
-
 @total_ordering
 class Entity:
     """Represents an Entity in an energy system graph.
@@ -50,12 +46,10 @@ class Entity:
         information.
     """
 
-    __slots__ = ["_label", "_in_edges", "_inputs", "_outputs"]
+    __slots__ = ["_label"]
 
     def __init__(self, *args, **kwargs):
         args = list(args)
-        self._inputs = Inputs(self)
-        self._outputs = Outputs(self)
         for optional in ["label"]:
             if optional in kwargs:
                 if args:
@@ -107,24 +101,3 @@ class Entity:
     @label.setter
     def label(self, label):
         self._label = label
-
-    @property
-    def inputs(self):
-        """dict:
-        Dictionary mapping input :class:`Entities <Entity>` :obj:`n` to
-        :class:`Edge`s from :obj:`n` into :obj:`self`.
-        If :obj:`self` is an :class:`Edge`, returns a dict containing the
-        :class:`Edge`'s single input node as the key and the flow as the value.
-        """
-        return self._inputs
-
-    @property
-    def outputs(self):
-        """dict:
-        Dictionary mapping output :class:`Entities <Entity>` :obj:`n` to
-        :class:`Edges` from :obj:`self` into :obj:`n`.
-        If :obj:`self` is an :class:`Edge`, returns a dict containing the
-        :class:`Edge`'s single output node as the key and the flow as the
-        value.
-        """
-        return self._outputs

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -14,6 +14,7 @@ SPDX-License-Identifier: MIT
 
 from functools import total_ordering
 
+
 @total_ordering
 class Entity:
     """Represents an Entity in an energy system graph.

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -13,6 +13,8 @@ SPDX-License-Identifier: MIT
 
 from .edge import Edge
 from .entity import Entity
+from .helpers import Inputs
+from .helpers import Outputs
 
 
 class Node(Entity):
@@ -29,9 +31,13 @@ class Node(Entity):
         output nodes to corresponding outflows (i.e. output values).
     """
 
+    __slots__ = ["_in_edges", "_inputs", "_outputs"]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self._inputs = Inputs(self)
+        self._outputs = Outputs(self)
         self._in_edges = set()
 
         msg = "{} {!r} of {!r} not an instance of Node but of {}."
@@ -57,6 +63,27 @@ class Node(Entity):
             edge = Edge.from_object(flow)
             edge.input = self
             edge.output = o
+
+    @property
+    def inputs(self):
+        """dict:
+        Dictionary mapping input :class:`Entities <Entity>` :obj:`n` to
+        :class:`Edge`s from :obj:`n` into :obj:`self`.
+        If :obj:`self` is an :class:`Edge`, returns a dict containing the
+        :class:`Edge`'s single input node as the key and the flow as the value.
+        """
+        return self._inputs
+
+    @property
+    def outputs(self):
+        """dict:
+        Dictionary mapping output :class:`Entities <Entity>` :obj:`n` to
+        :class:`Edges` from :obj:`self` into :obj:`n`.
+        If :obj:`self` is an :class:`Edge`, returns a dict containing the
+        :class:`Edge`'s single output node as the key and the flow as the
+        value.
+        """
+        return self._outputs
 
 
 class Bus(Node):


### PR DESCRIPTION
This cleanup seems to have been forgotten when the Entity was introduced to replace the former Node that was parent to Edge.

Note: Merge-commit message should include a statement that `Edge.inputs` (plural) is not used and is rather confusing.