### PR TITLE
Deprecate child classes of Node

### DIFF
--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -65,6 +65,7 @@ _deprecation_warning = (
     "Usage of {} is deprecated. Use oemof.network.Node instead."
 )
 
+
 class Bus(Node):
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -11,6 +11,8 @@ SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>
 SPDX-License-Identifier: MIT
 """
 
+import warnings
+
 from .edge import Edge
 from .entity import Entity
 
@@ -59,12 +61,26 @@ class Node(Entity):
             edge.output = o
 
 
+_deprecation_warning = (
+    "Usage of {} is deprecated. Use oemof.network.Node instead."
+)
+
 class Bus(Node):
-    pass
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            _deprecation_warning.format(type(self)),
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class Component(Node):
-    pass
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            _deprecation_warning.format(type(self)),
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class Sink(Component):

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -341,6 +341,7 @@ class TestsEnergySystemNodesIntegration:
         self.es.add(n3)
         assert n3 in self.es.nodes
 
+
 def test_deprecated_classes():
     with pytest.warns(FutureWarning):
         Bus()

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -21,6 +21,8 @@ import pytest
 
 from oemof.network.energy_system import EnergySystem as EnSys
 from oemof.network.network import Bus
+from oemof.network.network import Sink
+from oemof.network.network import Source
 from oemof.network.network import Transformer
 from oemof.network.network.edge import Edge
 from oemof.network.network.entity import Entity
@@ -124,7 +126,7 @@ class TestsNode:
         """
         flow = object()
         old = Node(label="A reused label")
-        bus = Bus(label="bus", inputs={old: flow})
+        bus = Node(label="bus", inputs={old: flow})
         assert bus.inputs[old].flow == flow, (
             ("\n  Expected: {0}" + "\n  Got     : {1} instead").format(
                 flow, bus.inputs[old].flow
@@ -172,7 +174,7 @@ class TestsNode:
     def test_modifying_inputs_after_construction(self):
         """One should be able to add and delete inputs of a node."""
         node = Node("N1")
-        bus = Bus("N2")
+        bus = Node("N2")
         flow = "flow"
 
         assert node.inputs == {}, (
@@ -329,12 +331,22 @@ class TestsEnergySystemNodesIntegration:
         self.es = EnSys()
 
     def test_entity_registration(self):
-        b1 = Bus(label="<B1>")
-        self.es.add(b1)
-        assert self.es.nodes[0] == b1
-        b2 = Bus(label="<B2>")
-        self.es.add(b2)
-        assert self.es.nodes[1] == b2
-        t1 = Transformer(label="<TF1>", inputs=[b1], outputs=[b2])
-        self.es.add(t1)
-        assert t1 in self.es.nodes
+        n1 = Node(label="<B1>")
+        self.es.add(n1)
+        assert self.es.nodes[0] == n1
+        n2 = Node(label="<B2>")
+        self.es.add(n2)
+        assert self.es.nodes[1] == n2
+        n3 = Node(label="<TF1>", inputs=[n1], outputs=[n2])
+        self.es.add(n3)
+        assert n3 in self.es.nodes
+
+def test_deprecated_classes():
+    with pytest.warns(FutureWarning):
+        Bus()
+    with pytest.warns(FutureWarning):
+        Sink()
+    with pytest.warns(FutureWarning):
+        Source()
+    with pytest.warns(FutureWarning):
+        Transformer()


### PR DESCRIPTION
All subclasses to Node (Bus, Component, Sink, Source, and Transformer) do not implement any additional functionality. This prepares their deletion.

Fixes #29