### PR TITLE
Feature/custom properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,4 +20,4 @@ Changelog
 -----
 
 * Improved code quality
-
+* Add Entity.custom_properties

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -60,7 +60,7 @@ class Entity:
 
     def __init__(self, label=None, custom_properties=None, **kwargs):
         self._label = label
-        if custom_properties == None:
+        if custom_properties is None:
             custom_properties = {}
         self.custom_properties = custom_properties
         self._inputs = Inputs(self)

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -52,25 +52,10 @@ class Entity:
 
     __slots__ = ["_label", "_in_edges", "_inputs", "_outputs"]
 
-    def __init__(self, *args, **kwargs):
-        args = list(args)
+    def __init__(self, label=None, **kwargs):
+        self._label = label
         self._inputs = Inputs(self)
         self._outputs = Outputs(self)
-        for optional in ["label"]:
-            if optional in kwargs:
-                if args:
-                    raise (
-                        TypeError(
-                            (
-                                "{}.__init__()\n"
-                                "  got multiple values for argument '{}'"
-                            ).format(type(self), optional)
-                        )
-                    )
-                setattr(self, "_" + optional, kwargs[optional])
-            else:
-                if args:
-                    setattr(self, "_" + optional, args.pop())
 
     def __eq__(self, other):
         return id(self) == id(other)
@@ -100,7 +85,7 @@ class Entity:
         """
         return (
             self._label
-            if hasattr(self, "_label")
+            if self._label
             else "<{} #0x{:x}>".format(type(self).__name__, id(self))
         )
 

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -50,10 +50,19 @@ class Entity:
         information.
     """
 
-    __slots__ = ["_label", "_in_edges", "_inputs", "_outputs"]
+    __slots__ = [
+        "_label",
+        "_in_edges",
+        "_inputs",
+        "_outputs",
+        "custom_properties",
+    ]
 
-    def __init__(self, label=None, **kwargs):
+    def __init__(self, label=None, custom_properties=None, **kwargs):
         self._label = label
+        if custom_properties == None:
+            custom_properties = {}
+        self.custom_properties = custom_properties
         self._inputs = Inputs(self)
         self._outputs = Outputs(self)
 

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -42,6 +42,10 @@ class Entity:
         representation of this node will instead be generated based on this
         nodes `class` and `id`.
 
+    custom_properties: `dict`
+        This dictionary that can be used to store information that can be used
+        to easily attach custom information to any Entity.
+
     Attributes
     ----------
     __slots__: str or iterable of str

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -58,7 +58,7 @@ class Entity:
         "custom_properties",
     ]
 
-    def __init__(self, label=None, custom_properties=None, **kwargs):
+    def __init__(self, label=None, *, custom_properties=None, **kwargs):
         self._label = label
         if custom_properties is None:
             custom_properties = {}

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -94,7 +94,7 @@ class Entity:
         """
         return (
             self._label
-            if self._label
+            if self._label is not None
             else "<{} #0x{:x}>".format(type(self).__name__, id(self))
         )
 

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -366,6 +366,7 @@ def test_custom_properties():
     assert node1.custom_properties["foo"] == "bar"
     assert node1.custom_properties[1] == 2
 
+
 def test_comparision():
     node0 = Node(label=0)
     node1 = Node(label=2)

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -253,11 +253,10 @@ class TestsNode:
 
     def test_node_label_without_private_attribute(self):
         """
-        A `Node` with no explicit `label` doesn't have a `_label` attribute.
+        A `Node` without `label` doesn't have the `_label` attribute set.
         """
         n = Node()
-        with pytest.raises(AttributeError):
-            n._label
+        assert not n._label
 
     def test_node_label_if_its_not_explicitly_specified(self):
         """If not explicitly given, a `Node`'s label is based on its `id`."""

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -365,3 +365,11 @@ def test_custom_properties():
     )
     assert node1.custom_properties["foo"] == "bar"
     assert node1.custom_properties[1] == 2
+
+def test_comparision():
+    node0 = Node(label=0)
+    node1 = Node(label=2)
+    node2 = Node(label=-5)
+
+    assert node0 < node1
+    assert node0 > node2

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -350,3 +350,18 @@ def test_deprecated_classes():
         Source()
     with pytest.warns(FutureWarning):
         Transformer()
+
+
+def test_custom_properties():
+    node0 = Node()
+
+    assert not node0.custom_properties
+
+    node1 = Node(
+        custom_properties={
+            "foo": "bar",
+            1: 2,
+        }
+    )
+    assert node1.custom_properties["foo"] == "bar"
+    assert node1.custom_properties[1] == 2


### PR DESCRIPTION
The custom_properties is a dictionary that can be used to store information that can be used to easily attach custom information to any Entity.

This also simplifies the class `Entity` by quite a lot. There was a rather complicated construction of branches and loops so that Node only has a _label if there is a label set. Now, there is always a _label,  but it is set to None by default, making the whole looping and branching unnecessary.

Implements #22