### PR TITLE
Remove __slots__ and corresponding test

### DIFF
--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -44,7 +44,6 @@ class Entity:
         to easily attach custom information to any Entity.
     """
 
-
     def __init__(self, label=None, *, custom_properties=None, **kwargs):
         self._label = label
         if custom_properties is None:

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -42,19 +42,8 @@ class Entity:
     custom_properties: `dict`
         This dictionary that can be used to store information that can be used
         to easily attach custom information to any Entity.
-
-    Attributes
-    ----------
-    __slots__: str or iterable of str
-        See the Python documentation on `__slots__
-        <https://docs.python.org/3/reference/datamodel.html#slots>`_ for more
-        information.
     """
 
-    __slots__ = [
-        "_label",
-        "custom_properties",
-    ]
 
     def __init__(self, label=None, *, custom_properties=None, **kwargs):
         self._label = label

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -42,8 +42,6 @@ class Node(Entity):
         A dictionary mapping output nodes to corresponding outflows.
     """
 
-    __slots__ = ["_in_edges", "_inputs", "_outputs"]
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -33,11 +33,6 @@ class TestsNode:
     def setup_method(self):
         self.energysystem = EnSys()
 
-    def test_that_attributes_cannot_be_added(self):
-        entity = Entity()
-        with pytest.raises(AttributeError):
-            entity.foo = "bar"
-
     def test_symmetric_input_output_assignment(self):
         n1 = Node(label="<N1>")
 

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -33,6 +33,10 @@ class TestsNode:
     def setup_method(self):
         self.energysystem = EnSys()
 
+    def test_entity_initialisation(self):
+        entity = Entity(label="foo")
+        assert entity.label == "foo"
+
     def test_symmetric_input_output_assignment(self):
         n1 = Node(label="<N1>")
 


### PR DESCRIPTION
__slots__ in network have no (positive) effect anyway, as just subclasses are used.