### PR TITLE
Require label of Node to be given

### DIFF
--- a/src/oemof/network/network/edge.py
+++ b/src/oemof/network/network/edge.py
@@ -102,7 +102,7 @@ class Edge(Entity):
     @input.setter
     def input(self, i):
         old_input = self.input
-        self.label = Edge.Label(i, self.label.output)
+        self._label = Edge.Label(i, self.label.output)
         if old_input is None and i is not None and self.output is not None:
             i.outputs[self.output] = self
 
@@ -113,6 +113,6 @@ class Edge(Entity):
     @output.setter
     def output(self, o):
         old_output = self.output
-        self.label = Edge.Label(self.label.input, o)
+        self._label = Edge.Label(self.label.input, o)
         if old_output is None and o is not None and self.input is not None:
             o.inputs[self.input] = self

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -78,7 +78,7 @@ class Entity:
         """
         try:
             return self._label if self._label is not None else self._id_label
-        except AttributeError:
+        except AttributeError:  # Workaround for problems with pickle/dill
             return hash(self._id_label)
 
     @property

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -44,7 +44,7 @@ class Entity:
         to easily attach custom information to any Entity.
     """
 
-    def __init__(self, label=None, *, custom_properties=None):
+    def __init__(self, label, *, custom_properties=None):
         self._label = label
         if custom_properties is None:
             custom_properties = {}
@@ -84,7 +84,3 @@ class Entity:
     @property
     def _id_label(self):
         return "<{} #0x{:x}>".format(type(self).__name__, id(self))
-
-    @label.setter
-    def label(self, label):
-        self._label = label

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -44,7 +44,7 @@ class Node(Entity):
 
     def __init__(
         self,
-        label=None,
+        label,
         *,
         inputs=None,
         outputs=None,

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -363,7 +363,7 @@ def test_custom_properties():
         custom_properties={
             "foo": "bar",
             1: 2,
-        }
+        },
     )
     assert node1.custom_properties["foo"] == "bar"
     assert node1.custom_properties[1] == 2

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -60,7 +60,7 @@ class TestsNode:
         )
 
     def test_accessing_outputs_of_a_node_without_output_flows(self):
-        n = Node()
+        n = Node(label="node")
         exception = None
         outputs = None
         try:
@@ -79,7 +79,7 @@ class TestsNode:
         )
 
     def test_accessing_inputs_of_a_node_without_input_flows(self):
-        n = Node()
+        n = Node(label="node")
         exception = None
         inputs = None
         try:
@@ -98,7 +98,7 @@ class TestsNode:
         )
 
     def test_that_the_outputs_attribute_of_a_node_is_a_mapping(self):
-        n = Node()
+        n = Node(label="node")
         exception = None
         try:
             n.outputs.values()
@@ -252,16 +252,16 @@ class TestsNode:
         with pytest.raises(ValueError):
             Node("An entity with an input", inputs={"Not a Node": "A Flow"})
 
-    def test_node_label_without_private_attribute(self):
+    def test_node_requires_label(self):
         """
-        A `Node` without `label` doesn't have the `_label` attribute set.
+        A `Node` without `label` cannot be constructed.
         """
-        n = Node()
-        assert not n._label
+        with pytest.raises(TypeError):
+            _ = Node()
 
     def test_node_label_if_its_not_explicitly_specified(self):
         """If not explicitly given, a `Node`'s label is based on its `id`."""
-        n = Node()
+        n = Node(label=None)
         assert "0x{:x}>".format(id(n)) in n.label
 
 
@@ -344,21 +344,22 @@ class TestsEnergySystemNodesIntegration:
 
 def test_deprecated_classes():
     with pytest.warns(FutureWarning):
-        Bus()
+        Bus("bus")
     with pytest.warns(FutureWarning):
-        Sink()
+        Sink("sink")
     with pytest.warns(FutureWarning):
-        Source()
+        Source("source")
     with pytest.warns(FutureWarning):
-        Transformer()
+        Transformer("transformer")
 
 
 def test_custom_properties():
-    node0 = Node()
+    node0 = Node("n0")
 
     assert not node0.custom_properties
 
     node1 = Node(
+        "n1",
         custom_properties={
             "foo": "bar",
             1: 2,


### PR DESCRIPTION
We use labels for hashing of Nodes and also save them to a dict where the labels are used as keys. Thus, we implicitly assume that labels are constant. In my opinion, we should drop the default "None" from the labels, encouraging users to set them. Also, the label setter should be removed, as it is incompatible to the new dictionary approach.