### PR TITLE
Move to setup-python@v5

### DIFF
--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install xmllint
       run: sudo apt install coinor-cbc
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
The version we use until now (v2) is deprecated and depends on old Javascript, as far as I understand. Support will be dropped soon.

Closes #41 