### PR TITLE
Add check method to EnergySystem class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,3 +25,5 @@ Changelog
 
 0.5.1
 -----
+
+* Added EnergySystem.check() to check graph for sanity

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -219,16 +219,16 @@ class EnergySystem:
     def check(self):
         error_message = (
             "Node {n} not part of EnergySystem "
-            + "but Flow ({n}, {o}) exists."
+            + "but Flow ({i}, {o}) exists."
         )
 
         for n in self.nodes:
             for o in n.outputs.keys():
                 if o not in self.nodes:
-                    raise RuntimeError(error_message.format(n=n, o=o))
+                    raise RuntimeError(error_message.format(n=n, i=n, o=o))
             for i in n.inputs.keys():
                 if i not in self.nodes:
-                    raise RuntimeError(error_message.format(n=i, o=n))
+                    raise RuntimeError(error_message.format(n=n, i=i, o=n))
 
     def dump(self, dpath=None, filename=None):
         r"""Dump an EnergySystem instance."""

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -216,6 +216,20 @@ class EnergySystem:
             for target in source.outputs
         }
 
+    def check(self):
+        error_message = (
+            "Node {n} not part of EnergySystem "
+            + "but Flow ({n}, {o}) exists."
+        )
+
+        for n in self.nodes:
+            for o in n.outputs.keys():
+                if o not in self.nodes:
+                    raise RuntimeError(error_message.format(n=n, o=o))
+            for i in n.inputs.keys():
+                if i not in self.nodes:
+                    raise RuntimeError(error_message.format(n=i, o=n))
+
     def dump(self, dpath=None, filename=None):
         r"""Dump an EnergySystem instance."""
         if dpath is None:

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -78,6 +78,38 @@ class TestsEnergySystem:
         assert (node1, node2) in self.es.flows().keys()
         assert (node2, node1) in self.es.flows().keys()
 
+    def test_check_method(self):
+        node0 = Node(label="node0")
+        node1 = Node(label="node1")
+        node2 = Node(label="node2")
+        node3 = Node(label="node3", inputs={node2: Edge()})
+        self.es.check()  # empty, no problem
+
+        self.es.add(node0)
+        self.es.check()  # single node, no problem
+
+        node0.outputs[node1] = Edge()
+        with pytest.raises(RuntimeError, match="not part of EnergySystem"):
+            self.es.check()  # node1 needs to be added
+
+        self.es.add(node1)
+        self.es.check()  # consistent graph added, no problem
+
+        # The check method is not needed for these cases.
+        # I still add them to the test for completeness.
+        with pytest.raises(KeyError):
+            node2.outputs[node1]  # not allowed anyway
+        with pytest.raises(KeyError):
+            node1.inputs[node2]  # also not allowed
+        self.es.check()  # graph still consistent
+
+        self.es.add(node2)
+        with pytest.raises(RuntimeError, match="not part of EnergySystem"):
+            self.es.check()  # if node 2 is present, node3 also needs to be
+
+        self.es.add(node3)
+        self.es.check()  # Now, everything is fine.
+
     def test_that_node_additions_are_signalled(self):
         """
         When a node gets `add`ed, a corresponding signal should be emitted.


### PR DESCRIPTION
The method checks if every Node that is connected via an Edge is part of the EnergySystem and raises a RuntimeError if not.

As an alternative approach, I tried to check indirectly by creating a `networkx` graph. However, that package implicitly adds nodes an edge connects with.