### PR TITLE
Allow path objects for nx graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,3 +30,4 @@ Changelog
 * Added EnergySystem.check() to check graph for sanity
 * Updated build system from setup.py to "build" module
 * Added SubNetwork to build hierachical graphs
+* create_nx_graph(...) now accepts Path objects

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -7,7 +7,7 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/oemof/energy_system.py
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/src/oemof/network/graph.py
+++ b/src/oemof/network/graph.py
@@ -52,7 +52,7 @@ def create_nx_graph(
     >>> import pandas as pd
     >>> from oemof.network.network import Node
     >>> from oemof.network.energy_system import EnergySystem
-    >>> import oemof.network.graph as grph
+    >>> import oemof.network.graph as graph
     >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='h')
     >>> es = EnergySystem(timeindex=datetimeindex)
     >>> b_gas = Node(label='b_gas')
@@ -66,24 +66,24 @@ def create_nx_graph(
     >>> line_from2 = Node(label='line_from2',
     ...                   inputs=[bel2], outputs=[bel1])
     >>> es.add(b_gas, bel1, demand_el, pp_gas, bel2, line_to2, line_from2)
-    >>> my_graph = grph.create_nx_graph(es)
+    >>> my_graph = graph.create_nx_graph(es)
     >>> # export graph as .graphml for programs like Yed where it can be
     >>> # sorted and customized. this is especially helpful for large graphs
     >>> # grph.create_nx_graph(es, filename="my_graph.graphml")
-    >>> [my_graph.has_node(n)
-    ...  for n in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
+    >>> [my_graph.has_node(nd)
+    ...  for nd in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
     [True, True, True, True, False]
     >>> list(nx.attracting_components(my_graph))
     [{'demand_el'}]
     >>> sorted(list(nx.strongly_connected_components(my_graph))[1])
     ['bel1', 'bel2', 'line_from2', 'line_to2']
-    >>> new_graph = grph.create_nx_graph(energy_system=es,
+    >>> new_graph = graph.create_nx_graph(energy_system=es,
     ...                                  remove_nodes_with_substrings=['b_'],
     ...                                  remove_nodes=["('pp', 'gas')"],
     ...                                  remove_edges=[('bel2', 'line_from2')],
     ...                                  filename='test_graph')
-    >>> [new_graph.has_node(n)
-    ...  for n in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
+    >>> [new_graph.has_node(nd)
+    ...  for nd in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
     [False, True, False, True, False]
     >>> my_graph.has_edge("('pp', 'gas')", 'bel1')
     True

--- a/src/oemof/network/graph.py
+++ b/src/oemof/network/graph.py
@@ -140,7 +140,5 @@ def create_nx_graph(
                 grph.remove_nodes_from(remove_nodes)
 
         if filename is not None:
-            filename = Path(filename)
-            filename.with_suffix(".graphml")
-            nx.write_graphml(grph, filename)
+            nx.write_graphml(grph, Path(filename).with_suffix(".graphml"))
         return grph

--- a/src/oemof/network/graph.py
+++ b/src/oemof/network/graph.py
@@ -13,6 +13,7 @@ SPDX-License-Identifier: MIT
 """
 
 import warnings
+from pathlib import Path
 
 import networkx as nx
 
@@ -32,7 +33,7 @@ def create_nx_graph(
     ----------
     energy_system : `oemof.solph.network.EnergySystem`
 
-    filename : str
+    filename : str or Path
         Absolute filename (with path) to write your graph in the graphml
         format. If no filename is given no file will be written.
 
@@ -139,8 +140,7 @@ def create_nx_graph(
                 grph.remove_nodes_from(remove_nodes)
 
         if filename is not None:
-            if filename[-8:] != ".graphml":
-                filename = filename + ".graphml"
+            filename = Path(filename)
+            filename.with_suffix(".graphml")
             nx.write_graphml(grph, filename)
-
         return grph

--- a/src/oemof/network/graph.py
+++ b/src/oemof/network/graph.py
@@ -7,7 +7,7 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/oemof/graph.py
 
 SPDX-FileCopyrightText: Simon Hilpert <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 
 SPDX-License-Identifier: MIT
 """

--- a/src/oemof/network/groupings.py
+++ b/src/oemof/network/groupings.py
@@ -7,7 +7,7 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/oemof/groupings.py
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>
 
 SPDX-License-Identifier: MIT

--- a/src/oemof/network/network/edge.py
+++ b/src/oemof/network/network/edge.py
@@ -4,7 +4,7 @@
 energy systems.
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/src/oemof/network/network/entity.py
+++ b/src/oemof/network/network/entity.py
@@ -4,7 +4,7 @@
 energy systems.
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/src/oemof/network/network/helpers.py
+++ b/src/oemof/network/network/helpers.py
@@ -3,7 +3,7 @@
 """This package contains helpers used by Entities of the energy systems.
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/src/oemof/network/network/hierachical_nodes.py
+++ b/src/oemof/network/network/hierachical_nodes.py
@@ -3,7 +3,7 @@
 modelling an energy system graph.
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -3,7 +3,7 @@
 modelling an energy system graph.
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: MIT
 from pathlib import Path
 
 import pytest
+from networkx import DiGraph
 
 from oemof.network import graph
 from oemof.network.energy_system import EnergySystem
@@ -292,8 +293,10 @@ class TestsEnergySystem:
     def test_graph(self):
         fpath = Path(Path.home(), "test_graph_x345_efhu73.graphml")
         my_graph = graph.create_nx_graph(self.es)
+        assert isinstance(my_graph, DiGraph)
         assert not fpath.is_file()
         my_graph = graph.create_nx_graph(self.es, filename=fpath)
+        assert isinstance(my_graph, DiGraph)
         assert fpath.is_file()
         fpath.unlink()
         assert not fpath.is_file()

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -294,9 +294,14 @@ class TestsEnergySystem:
         fpath = Path(Path.home(), "test_graph_x345_efhu73.graphml")
         my_graph = graph.create_nx_graph(self.es)
         assert isinstance(my_graph, DiGraph)
+
+        # make sure that test does not pass because of pre-existing file
         assert not fpath.is_file()
+
+        # create graph file
         my_graph = graph.create_nx_graph(self.es, filename=fpath)
         assert isinstance(my_graph, DiGraph)
         assert fpath.is_file()
+
+        # clean up (delete graph file)
         fpath.unlink()
-        assert not fpath.is_file()

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -14,8 +14,11 @@ SPDX-FileCopyrightText: Pierre-Francois Duc <pierre-francois@rl-institut.de>
 SPDX-License-Identifier: MIT
 """
 
+from pathlib import Path
+
 import pytest
 
+from oemof.network import graph
 from oemof.network.energy_system import EnergySystem
 from oemof.network.network import AtomicNode
 from oemof.network.network import Edge
@@ -285,3 +288,12 @@ class TestsEnergySystem:
             "Got {}.\n"
             "Probable reason: `subscriber` didn't get called."
         ).format(subscriber.called)
+
+    def test_graph(self):
+        fpath = Path(Path.home(), "test_graph_x345_efhu73.graphml")
+        my_graph = graph.create_nx_graph(self.es)
+        assert not fpath.is_file()
+        my_graph = graph.create_nx_graph(self.es, filename=fpath)
+        assert fpath.is_file()
+        fpath.unlink()
+        assert not fpath.is_file()

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -5,7 +5,7 @@
 This file is part of project oemof.network (github.com/oemof/oemof-network).
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>
@@ -210,7 +210,7 @@ class TestsEnergySystem:
         self.es.add(subnetwork)
         assert len(self.es.nodes) == 3
 
-        assert self.es.node[("leaf1" , "root")] == leaf1
+        assert self.es.node[("leaf1", "root")] == leaf1
 
     def test_add_flow_assignment(self):
         assert not self.es.nodes

--- a/tests/test_groupings/test_groupings_basic.py
+++ b/tests/test_groupings/test_groupings_basic.py
@@ -5,7 +5,7 @@
 This file is part of project oemof.network (github.com/oemof/oemof-network).
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/tests/test_groupings/test_groupings_in_es.py
+++ b/tests/test_groupings/test_groupings_in_es.py
@@ -5,7 +5,7 @@
 This file is part of project oemof.network (github.com/oemof/oemof-network).
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -7,7 +7,7 @@ by the contributors recorded in the version control history of the file,
 available from its original location oemof/tests/test_network_classes.py
 
 SPDX-FileCopyrightText: Stephan Günther <>
-SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>


### PR DESCRIPTION
At the moment the path has to be a string but I want to allow pathlib objects as well.

In some local doctests the doctest includes package variables. To avoid this it is important to name them differently. It is just a renaming that will not harm anybody.