### PR TITLE
Replace coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,6 @@ branch = true
 relative_files = true
 source =
     src
-    tests
 parallel = true
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source = src
 
 [run]
 branch = true
+relative_files = true
 source =
     src
     tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["tox pytests"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -14,9 +14,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Git clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.default_python || '3.10' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ env.default_python || '3.10' }}"
 

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -1,3 +1,5 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
+
 name: tox pytests
 
 on:
@@ -32,6 +34,57 @@ jobs:
         pip install tox tox-gh-actions coverage
     - name: Test with tox
       run: tox -e py3
+      env:
+        COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
 
     - name: Check test coverage
       run: coverage report -m --fail-under=85
+      env:
+        COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
+
+    - name: Store coverage file
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.python_version }}
+        path: .coverage.${{ matrix.python_version }}
+        # By default hidden files/folders (i.e. starting with .) are ignored.
+        # You may prefer (for security reasons) not setting this and instead
+        # set COVERAGE_FILE above to not start with a `.`, but you cannot
+        # use "MERGE_COVERAGE_FILES: true" later on and need to manually
+        # combine the coverage file using "pipx run coverage combine"
+        include-hidden-files: true
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: pytest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is optional since by default it's to true. The git
+          # operations in python-coverage-comment-action utilize the token
+          # stored by actions/checkout.
+          persist-credentials: true
+
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_COVERAGE_FILES: true
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -29,15 +29,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions coverage coveralls
+        pip install tox tox-gh-actions coverage
     - name: Test with tox
       run: tox -e py3
 
     - name: Check test coverage
       run: coverage report -m --fail-under=85
-
-    - name: Report to coveralls
-      run: coveralls
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -35,18 +35,22 @@ jobs:
     - name: Test with tox
       run: tox -e py3
       env:
-        COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+        # The file name prefix must be ".coverage." for "coverage combine"
+        # enabled by "MERGE_COVERAGE_FILES: true" to work. A "subprocess"
+        # error with the message "No data to combine" will be triggered if
+        # this prefix is not used.
 
     - name: Check test coverage
       run: coverage report -m --fail-under=85
       env:
-        COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
 
     - name: Store coverage file
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ matrix.python_version }}
-        path: .coverage.${{ matrix.python_version }}
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage.${{ matrix.python-version }}
         # By default hidden files/folders (i.e. starting with .) are ignored.
         # You may prefer (for security reasons) not setting this and instead
         # set COVERAGE_FILE above to not start with a `.`, but you cannot

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -19,11 +19,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install xmllint
       run: sudo apt install coinor-cbc
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Overview
       - |docs|
     * - tests
       - | |tox-pytest| |tox-checks|
-        | |coveralls| |codacy|
+        | |codacy|
     * - package
       - | |version| |wheel| |supported-versions| |supported-implementations|
         | |commits-since| |packaging|
@@ -28,10 +28,6 @@ Overview
 .. |docs| image:: https://readthedocs.org/projects/oemof-network/badge/?style=flat
     :target: https://readthedocs.org/projects/oemof-network
     :alt: Documentation Status
-
-.. |coveralls| image:: https://coveralls.io/repos/oemof/oemof-network/badge.svg?branch=dev&service=github
-    :alt: Coverage Status
-    :target: https://coveralls.io/r/oemof/oemof-network?branch=dev
 
 .. |codacy| image:: https://api.codacy.com/project/badge/Grade/39b648d0de3340da912c3dc48688a7b5
     :target: https://app.codacy.com/gh/oemof/oemof-network

--- a/tox.ini
+++ b/tox.ini
@@ -60,13 +60,6 @@ commands =
     sphinx-build {posargs:-E} -W -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
 
-[testenv:coveralls]
-deps =
-    coveralls
-skip_install = true
-commands =
-    coveralls []
-
 [testenv:codecov]
 deps =
     codecov

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 [testenv]
 basepython =
     docs: {env:TOXPYTHON:python3}
-    {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {bootstrap,clean,check,report,codecov}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Often, our CI tests fail just because coveralls is unreachable. The last outage was just the longest one. A second argument is, that CI tests should just make sure that local tests were run. If local tests pass, CI tests should also pass. With Coveralls, this is no longer the case. Thirdly, we often wave through merges even if coverage decreases. The reason is simple: If code is re-factored so that lines of code can be reduced (and tested lines are removed), often also nominal coverage decreases. Thus, the coverage (change) only has informative character anyway.

Concluding, I think it makes sense to remove coveralls from the CI pipeline. (I still like to have the coverage information accessible, nonetheless.)

- [x] Remove coveralls
- [x] Use https://github.com/py-cov-action/python-coverage-comment-action
- Add new GitHub internal badge. (Need to run action in dev, first.)

Implements #78

Process successfully tested at https://github.com/oemof/oemof-demand/pull/88, see https://htmlpreview.github.io/?https://github.com/oemof/oemof-demand/blob/python-coverage-comment-action-data/htmlcov/index.html for coverage report.