### PR TITLE
set the required python version to >=3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,3 +48,6 @@ Changelog
 * Properties "results", "timeindex", "timeincrement", and "temporal"
   of the class EnergySystem are now deprecated. They are not used (at least
   not at the level of oemof.network).
+* The required python version is upped to 3.10. This prevents problems in
+  environment creation and moves with the end-of-life-timeline of python 
+  versions.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,5 +17,8 @@ authors:
 - family-names: "Maldonado Castro"
   given-names: "Diana"
   orcid: https://orcid.org/0000-0001-8373-8913
+- family-names: "Schürmann"
+  given-names: "Lennart"
+  orcid: https://orcid.org/0000-0002-5624-232X
 title: "oemof.network"
 url: "https://github.com/oemof/oemof-network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "pandas",
     "blinker",


### PR DESCRIPTION
This is my attempt to fix the problematic behaviour described in #82. It pretty much does what the title says: it sets the version for `requires-python` in the `pyproject.toml` to `requires-python = ">=3.10"` as this is the oldest still supported python version.