### PR TITLE
Fix handover of references to energysystem

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,3 +48,4 @@ Changelog
 * Properties "results", "timeindex", "timeincrement", and "temporal"
   of the class EnergySystem are now deprecated. They are not used (at least
   not at the level of oemof.network).
+* Fixed passing references to the EnergySystem when adding Nodes as subnodes.

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -67,14 +67,14 @@ class Node(Entity):
         self._outputs = Outputs(self)
         self._in_edges = set()
 
-        if parent_node is not None:
-            parent_node.add(self)
-        else:
-            self._parent = None
-            self._depth = 0
+        self._parent = None
+        self._depth = 0
 
         self.__subnodes = []
         self.__energy_system = None
+
+        if parent_node is not None:
+            parent_node.add(self)
 
         # TODO: Try to avoid this local `import`.
         from ..energy_system import EnergySystem
@@ -162,6 +162,7 @@ class Node(Entity):
             self.__subnodes.append(subnode)
             if self.__energy_system is not None:
                 self.__energy_system.add(subnode)
+                subnode.__energy_system = self.__energy_system
 
     def subnode(self, class_, local_name, *args, **kwargs):
         """Create a subnode and add it to this `Node`.

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -70,8 +70,8 @@ class Node(Entity):
         self._parent = None
         self._depth = 0
 
-        self.__subnodes = []
-        self.__energy_system = None
+        self._subnodes = []
+        self._energy_system = None
 
         if parent_node is not None:
             parent_node.add(self)
@@ -147,7 +147,7 @@ class Node(Entity):
         It is deliberately provided as a tuple to prevent user to append
         subnodes other than with API methods.
         """
-        return tuple([sn for sn in self.__subnodes])
+        return tuple([sn for sn in self._subnodes])
 
     @property
     def parent(self) -> Node:
@@ -159,10 +159,10 @@ class Node(Entity):
         for subnode in subnodes:
             subnode._parent = self
             subnode._depth = self.depth + 1
-            self.__subnodes.append(subnode)
-            if self.__energy_system is not None:
-                self.__energy_system.add(subnode)
-                subnode.__energy_system = self.__energy_system
+            self._subnodes.append(subnode)
+            if self._energy_system is not None:
+                self._energy_system.add(subnode)
+                subnode._energy_system = self._energy_system
 
     def subnode(self, class_, local_name, *args, **kwargs):
         """Create a subnode and add it to this `Node`.
@@ -230,9 +230,9 @@ class Node(Entity):
         #    Explain why the `node` argument is necessary.
         if self is not node:
             raise ValueError("Call needs to be obj._add_subnodes(obj).")
-        self.__energy_system = kwargs["EnergySystem"]
+        self._energy_system = kwargs["EnergySystem"]
         deque(
-            (kwargs["EnergySystem"].add(sn) for sn in self.__subnodes),
+            (kwargs["EnergySystem"].add(sn) for sn in self._subnodes),
             maxlen=0,
         )
 

--- a/tests/test_subnode_integration.py
+++ b/tests/test_subnode_integration.py
@@ -1,0 +1,60 @@
+from oemof.network import EnergySystem
+from oemof.network import Node
+
+
+class TestNodeIntegration:
+    def test_energy_system_reference(self):
+        """Create Subnode with subnode() method"""
+        es = EnergySystem()
+
+        subnet = Node("parent")
+
+        subnode1 = Node("child1")
+        subnet.add(subnode1)
+
+        assert isinstance(subnet.subnodes, tuple)
+        assert len(subnet.subnodes) == 1
+        assert subnet.subnodes[-1] == subnode1
+        assert subnode1.parent == subnet
+        assert subnode1.depth == 1
+        assert subnode1.label == "child1"
+        assert subnode1._energy_system is None
+
+        subnode2 = subnet.subnode(Node, "child2")
+
+        assert isinstance(subnet.subnodes, tuple)
+        assert len(subnet.subnodes) == 2
+        assert subnet.subnodes[-1] == subnode2
+        assert isinstance(subnode2, Node)
+        assert subnode2.parent == subnet
+        assert subnode2.depth == 1
+        assert subnode2.label == ("child2", "parent")
+        assert subnode2._energy_system is None
+
+        es.add(subnet)
+
+        assert subnet._energy_system == es
+        assert subnode1._energy_system == es
+        assert subnode2._energy_system == es
+
+        subnode3 = Node("child3")
+        subnet.add(subnode3)
+
+        assert isinstance(subnet.subnodes, tuple)
+        assert len(subnet.subnodes) == 3
+        assert subnet.subnodes[-1] == subnode3
+        assert subnode3.parent == subnet
+        assert subnode3.depth == 1
+        assert subnode3.label == "child3"
+        assert subnode3._energy_system == es
+
+        subnode4 = subnet.subnode(Node, "child4")
+
+        assert isinstance(subnet.subnodes, tuple)
+        assert len(subnet.subnodes) == 4
+        assert subnet.subnodes[-1] == subnode4
+        assert isinstance(subnode4, Node)
+        assert subnode4.parent == subnet
+        assert subnode4.depth == 1
+        assert subnode4.label == ("child4", "parent")
+        assert subnode4._energy_system == es

--- a/tests/test_subnode_integration.py
+++ b/tests/test_subnode_integration.py
@@ -11,24 +11,9 @@ class TestNodeIntegration:
 
         subnode1 = Node("child1")
         subnet.add(subnode1)
-
-        assert isinstance(subnet.subnodes, tuple)
-        assert len(subnet.subnodes) == 1
-        assert subnet.subnodes[-1] == subnode1
-        assert subnode1.parent == subnet
-        assert subnode1.depth == 1
-        assert subnode1.label == "child1"
         assert subnode1._energy_system is None
 
         subnode2 = subnet.subnode(Node, "child2")
-
-        assert isinstance(subnet.subnodes, tuple)
-        assert len(subnet.subnodes) == 2
-        assert subnet.subnodes[-1] == subnode2
-        assert isinstance(subnode2, Node)
-        assert subnode2.parent == subnet
-        assert subnode2.depth == 1
-        assert subnode2.label == ("child2", "parent")
         assert subnode2._energy_system is None
 
         es.add(subnet)
@@ -39,22 +24,7 @@ class TestNodeIntegration:
 
         subnode3 = Node("child3")
         subnet.add(subnode3)
-
-        assert isinstance(subnet.subnodes, tuple)
-        assert len(subnet.subnodes) == 3
-        assert subnet.subnodes[-1] == subnode3
-        assert subnode3.parent == subnet
-        assert subnode3.depth == 1
-        assert subnode3.label == "child3"
         assert subnode3._energy_system == es
 
         subnode4 = subnet.subnode(Node, "child4")
-
-        assert isinstance(subnet.subnodes, tuple)
-        assert len(subnet.subnodes) == 4
-        assert subnet.subnodes[-1] == subnode4
-        assert isinstance(subnode4, Node)
-        assert subnode4.parent == subnet
-        assert subnode4.depth == 1
-        assert subnode4.label == ("child4", "parent")
         assert subnode4._energy_system == es


### PR DESCRIPTION
When adding subnodes, references to the EnergySystem (if present) were not correctly passed to newly created Node.

Without the change, the added test would fail.