### PR TITLE
Fix the local import of  EnergySystem within nodes.py module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ Changelog
   of the class EnergySystem are now deprecated. They are not used (at least
   not at the level of oemof.network).
 * Fixed passing references to the EnergySystem when adding Nodes as subnodes.
+* Add a method `connect_to_energy_system` to the Node class to assign a reference to the EnergySystem when a Node instance is added to it and to connect Node class methods with the signal sent when from the Energysystem when the Node instance is added.
 * The required python version is upped to 3.10. This prevents problems in
-  environment creation and moves with the end-of-life-timeline of python 
+  environment creation and moves with the end-of-life-timeline of python
   versions.

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -185,7 +185,7 @@ class EnergySystem:
         self._nodes.update(new_nodes)
         for n in nodes:
             n.connect_to_energy_system(self)
-            self.signals[type(self).add].send(n, EnergySystem=self)
+            self.signals[type(self).add].send(n)
 
     signals[add] = blinker.signal(add)
 

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -181,8 +181,10 @@ class EnergySystem:
                 + " b) multiple Nodes have identical labels, or"
                 + " c) multiple labels have the same string representation."
             )
+
         self._nodes.update(new_nodes)
         for n in nodes:
+            n.connect_to_energy_system(self)
             self.signals[type(self).add].send(n, EnergySystem=self)
 
     signals[add] = blinker.signal(add)

--- a/src/oemof/network/network/nodes.py
+++ b/src/oemof/network/network/nodes.py
@@ -76,13 +76,6 @@ class Node(Entity):
         if parent_node is not None:
             parent_node.add(self)
 
-        # TODO: Try to avoid this local `import`.
-        from ..energy_system import EnergySystem
-
-        EnergySystem.signals[EnergySystem.add].connect(
-            self._add_subnodes, sender=self
-        )
-
         if inputs is None:
             inputs = {}
         if outputs is None:
@@ -153,6 +146,13 @@ class Node(Entity):
     def parent(self) -> Node:
         """Get parent of this `Node`."""
         return self._parent
+
+    def connect_to_energy_system(self, energy_system):
+        """"""
+        self._energy_system = energy_system
+        energy_system.signals[type(energy_system).add].connect(
+            self._add_subnodes, sender=self
+        )
 
     def add(self, *subnodes):
         """Add subnodes to this `Node`."""
@@ -230,9 +230,8 @@ class Node(Entity):
         #    Explain why the `node` argument is necessary.
         if self is not node:
             raise ValueError("Call needs to be obj._add_subnodes(obj).")
-        self._energy_system = kwargs["EnergySystem"]
         deque(
-            (kwargs["EnergySystem"].add(sn) for sn in self._subnodes),
+            (self._energy_system.add(sn) for sn in self._subnodes),
             maxlen=0,
         )
 

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -350,7 +350,7 @@ class TestsEnergySystem:
 
         def subscriber(sender, **kwargs):
             assert sender is node
-            assert kwargs["EnergySystem"] is self.es
+            assert node._energy_system is self.es
             subscriber.called = True
 
         subscriber.called = False


### PR DESCRIPTION
Add a method `connect_to_energy_system` to the Node class to assign a reference to the EnergySystem when a Node instance is added to it and to connect Node class methods with the signal sent when from the Energysystem when the Node instance is added.