### PR TITLE
Streamline node removal from energy system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ lib64
 venv*/
 pyvenv*/
 pip-wheel-metadata/
+uv.lock
 
 # Installer logs
 pip-log.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,3 +52,5 @@ Changelog
 * The required python version is upped to 3.10. This prevents problems in
   environment creation and moves with the end-of-life-timeline of python 
   versions.
+* It is now possible to remove nodes from the EnergySystem using the function
+  EnergySystem.remove(node).

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -195,8 +195,22 @@ class EnergySystem:
         """
         Remove :class:`nodes <oemof.network.Node>` from this energy system.
         """
-        rm_nodes = {node.label: node for node in nodes}
-        rm_node_strings = {str(node) for node in nodes}
+        # perform BFS for subnodes
+        if any([n.subnodes for n in nodes]):
+            rm_nodes = dict()
+            queue = deque(nodes)
+            while queue:
+                node = queue.popleft()
+                if node.label in rm_nodes.keys():
+                    continue
+                rm_nodes[node.label] = node
+                for sn in node.subnodes:
+                    if sn.label not in rm_nodes.keys():
+                        queue.append(sn)
+        else:
+            rm_nodes = {node.label: node for node in nodes}
+        rm_node_strings = {str(node) for node in rm_nodes.values()}
+
         if self._node_strings.issuperset(rm_node_strings):
             self._node_strings.difference_update(rm_node_strings)
             for node_label in rm_nodes.keys():
@@ -214,7 +228,7 @@ class EnergySystem:
                 + " b) the Node has a different label than expected, or"
                 + " c) the Node was not added to the EnergySystem beforehand."
             )
-        for n in nodes:
+        for n in rm_nodes.values():
             self.signals[type(self).remove].send(n, EnergySystem=self)
 
     signals[remove] = blinker.signal(remove)

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -108,12 +108,15 @@ class EnergySystem:
     signals = {}
     """A dictionary of blinker_ signals emitted by energy systems.
 
-    Currently only one signal is supported. This signal is emitted whenever a
-    `node <oemof.network.Node>` is `add`ed to an energy system. The
-    signal's `sender` is set to the `node <oemof.network.Node>` that got
-    added to the energy system so that `node <oemof.network.Node>` have an
-    easy way to only receive signals for when they themselves get added to an
-    energy system.
+    Currently two signals are supported: `add` and `remove`.
+    The `add` signal is emitted whenever a `node <oemof.network.Node>` is
+    `add`ed to an energy system. The signal's `sender` is set to the 
+    `node <oemof.network.Node>` that got added to the energy system so that
+    `node <oemof.network.Node>` have an easy way to only receive signals for
+    when they themselves get added to an energy system.
+    The `remove` signal is emitted whenever a `node <oemof.network.Node>` is
+    `remove`d from an energy system. The signal is structured in the same way
+    as the `add` signal.
 
     .. _blinker: https://blinker.readthedocs.io/en/stable/
     """
@@ -187,6 +190,32 @@ class EnergySystem:
 
     signals[add] = blinker.signal(add)
 
+    def remove(self, *nodes):
+        """Remove :class:`nodes <oemof.network.Node>` from this energy system."""
+        rm_nodes = {node.label: node for node in nodes}
+        rm_node_strings = {str(node) for node in nodes}
+        if self._node_strings.issuperset(rm_node_strings):
+            self._node_strings.difference_update(rm_node_strings)
+            for node_label in rm_nodes.keys():
+                del self._nodes[node_label]
+        else:
+            unknown_strings = sorted(
+                list(self._node_strings - rm_node_strings)
+            )
+            raise ValueError(
+                "EnergySystem does not contain Node(s) with the following"
+                + ' string representation: "'
+                + '", "'.join(unknown_strings)
+                + '". This can be because'
+                + " a) you try to remove one Node more than once, "
+                + " b) the Node has a different label than expected, or"
+                + " c) the Node was not added to the EnergySystem beforehand."
+            )
+        for n in nodes:
+            self.signals[type(self).remove].send(n, EnergySystem=self)
+
+    signals[remove] = blinker.signal(remove)
+
     @property
     def groups(self):
         gs = self._groups
@@ -246,7 +275,6 @@ class EnergySystem:
 
         # iterate through edges and collect parent nodes
         for source, target in self.flows():
-
             # parents and great parent of source
             source_parent = source.parent
 

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -11,6 +11,7 @@ SPDX-FileCopyrightText: Uwe Krien <uwe.krien@ifam.fraunhofer.de>
 SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>
+SPDX-FileCopyrightText: Lennart Schürmann <>
 
 SPDX-License-Identifier: MIT
 """
@@ -110,7 +111,7 @@ class EnergySystem:
 
     Currently two signals are supported: `add` and `remove`.
     The `add` signal is emitted whenever a `node <oemof.network.Node>` is
-    `add`ed to an energy system. The signal's `sender` is set to the 
+    `add`ed to an energy system. The signal's `sender` is set to the
     `node <oemof.network.Node>` that got added to the energy system so that
     `node <oemof.network.Node>` have an easy way to only receive signals for
     when they themselves get added to an energy system.
@@ -191,7 +192,9 @@ class EnergySystem:
     signals[add] = blinker.signal(add)
 
     def remove(self, *nodes):
-        """Remove :class:`nodes <oemof.network.Node>` from this energy system."""
+        """
+        Remove :class:`nodes <oemof.network.Node>` from this energy system.
+        """
         rm_nodes = {node.label: node for node in nodes}
         rm_node_strings = {str(node) for node in nodes}
         if self._node_strings.issuperset(rm_node_strings):

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -195,7 +195,14 @@ class EnergySystem:
         """
         Remove :class:`nodes <oemof.network.Node>` from this energy system.
         """
-        # perform BFS for subnodes if necessary
+        # --- BEGIN: To be removed for versions >= v0.7 ---
+        warnings.warn(
+            "The function EnergySystem.remove() is experiemental."
+            + "It might change without further notice.",
+            ExperimentalFeatureWarning,
+        )
+        # --- END ---
+        # perform breadth first search to catch all subnodes for removal
         if any([n.subnodes for n in nodes]):
             rm_nodes = dict()
             queue = deque(nodes)

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -195,7 +195,7 @@ class EnergySystem:
         """
         Remove :class:`nodes <oemof.network.Node>` from this energy system.
         """
-        # --- BEGIN: To be removed for versions >= v0.7 ---
+        # --- BEGIN: To be removed when Node removal (including its API) is considered stable
         warnings.warn(
             "The function EnergySystem.remove() is experiemental."
             + "It might change without further notice.",

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -215,9 +215,9 @@ class EnergySystem:
             self._node_strings.difference_update(rm_node_strings)
             for node_label, node in rm_nodes.items():
                 del self._nodes[node_label]
-                # remove reference to node in parent (if existent)
                 if node.parent is not None:
                     node.parent._subnodes.remove(node)
+                node._energy_system = None
         else:
             unknown_strings = sorted(
                 list(self._node_strings - rm_node_strings)
@@ -233,6 +233,8 @@ class EnergySystem:
             )
         for n in rm_nodes.values():
             self.signals[type(self).remove].send(n, EnergySystem=self)
+        self._groups = {}
+        self._first_ungrouped_node_index_ = 0
 
     signals[remove] = blinker.signal(remove)
 

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -195,7 +195,7 @@ class EnergySystem:
         """
         Remove :class:`nodes <oemof.network.Node>` from this energy system.
         """
-        # --- BEGIN: To be removed when Node removal (including its API) is considered stable
+        # --- BEGIN: To be removed when Node removal (including API) is stable
         warnings.warn(
             "The function EnergySystem.remove() is experiemental."
             + "It might change without further notice.",

--- a/src/oemof/network/energy_system.py
+++ b/src/oemof/network/energy_system.py
@@ -195,7 +195,7 @@ class EnergySystem:
         """
         Remove :class:`nodes <oemof.network.Node>` from this energy system.
         """
-        # perform BFS for subnodes
+        # perform BFS for subnodes if necessary
         if any([n.subnodes for n in nodes]):
             rm_nodes = dict()
             queue = deque(nodes)
@@ -213,8 +213,11 @@ class EnergySystem:
 
         if self._node_strings.issuperset(rm_node_strings):
             self._node_strings.difference_update(rm_node_strings)
-            for node_label in rm_nodes.keys():
+            for node_label, node in rm_nodes.items():
                 del self._nodes[node_label]
+                # remove reference to node in parent (if existent)
+                if node.parent is not None:
+                    node.parent._subnodes.remove(node)
         else:
             unknown_strings = sorted(
                 list(self._node_strings - rm_node_strings)

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -305,6 +305,15 @@ class TestsEnergySystem:
         self.es.remove(leaf1)
         assert leaf1 not in subnetwork.subnodes
 
+    def test_energy_system_removal_subnode(self):
+        subnetwork = Node(label="root")
+        self.es.add(subnetwork)
+        leaf1 = subnetwork.subnode(Node, local_name="leaf1")
+        assert leaf1._energy_system == self.es
+
+        self.es.remove(leaf1)
+        assert leaf1._energy_system is None
+
     def test_add_populated_subnetwork(self):
         subnetwork = Node(label="root")
         leaf1 = subnetwork.subnode(Node, local_name="leaf1")

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -10,6 +10,7 @@ SPDX-FileCopyrightText: Simon Hilpert <>
 SPDX-FileCopyrightText: Cord Kaldemeyer <>
 SPDX-FileCopyrightText: Patrik Schönfeldt <patrik.schoenfeldt@dlr.de>
 SPDX-FileCopyrightText: Pierre-Francois Duc <pierre-francois@rl-institut.de>
+SPDX-FileCopyrightText: Lennart Schürmann <>
 
 SPDX-License-Identifier: MIT
 """
@@ -227,6 +228,19 @@ class TestsEnergySystem:
         # When both nodes are registred, also the Flow needs to be there.
         self.es.add(node2)
         assert node2 in self.es.nodes
+        assert (node1, node2) in self.es.flows().keys()
+
+    def test_remove_nodes(self):
+        assert not self.es.nodes
+        assert not self.es.flows()
+
+        node1 = Node(label="node1")
+        node2 = Node(label="node2", inputs={node1: Edge()})
+        self.es.add(node1, node2)
+        assert all([n in self.es.nodes for n in [node1, node2]])
+
+        self.es.remove(node2)
+        assert node2 not in self.es.nodes
         assert (node1, node2) in self.es.flows().keys()
 
     def test_enforce_unique_labels(self):

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -377,6 +377,31 @@ class TestsEnergySystem:
             "Probable reason: `subscriber` didn't get called."
         ).format(subscriber.called)
 
+    def test_that_node_removals_are_signalled(self):
+        """
+        When a node get `remove`d, a corresponding signal should be emitted.
+        """
+        node = Node(label="Node")
+        self.es.add(node)
+
+        def subscriber(sender, **kwargs):
+            assert sender is node
+            assert kwargs["EnergySystem"] is self.es
+            subscriber.called = True
+
+        subscriber.called = False
+
+        EnergySystem.signals[EnergySystem.remove].connect(
+            subscriber, sender=node
+        )
+        self.es.remove(node)
+        assert subscriber.called, (
+            "\nExpected `subscriber.called` to be `True`.\n"
+            "Got {}.\n"
+            "Probable reason: `subscriber` didn't get called upon node "
+            "removal."
+        ).format(subscriber.called)
+
     def test_graph_function(self):
         fpath = Path(Path.home(), "test_graph_x345_efhu73.graphml")
         with pytest.warns(

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -294,7 +294,7 @@ class TestsEnergySystem:
         assert len(self.es.nodes) == 2
 
         self.es.remove(subnetwork)
-        assert not bool(self.es.nodes)
+        assert len(self.es.nodes) == 0
 
     def test_removal_from_parent_nodes_subnodes_list(self):
         subnetwork = Node(label="root")
@@ -433,12 +433,6 @@ class TestsEnergySystem:
             subscriber, sender=node
         )
         self.es.remove(node)
-        assert subscriber.called, (
-            "\nExpected `subscriber.called` to be `True`.\n"
-            "Got {}.\n"
-            "Probable reason: `subscriber` didn't get called upon node "
-            "removal."
-        ).format(subscriber.called)
 
     def test_graph_function(self):
         fpath = Path(Path.home(), "test_graph_x345_efhu73.graphml")

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -241,7 +241,18 @@ class TestsEnergySystem:
 
         self.es.remove(node2)
         assert node2 not in self.es.nodes
+        # flow stays present when node2 is deleted
         assert (node1, node2) in self.es.flows().keys()
+
+    def test_remove_subnodes(self):
+        subnetwork = Node(label="root")
+        self.es.add(subnetwork)
+        leaf1 = subnetwork.subnode(Node, local_name="leaf1")
+        assert leaf1 in self.es.nodes
+
+        self.es.remove(leaf1)
+        assert leaf1 not in self.es.nodes
+        assert subnetwork in self.es.nodes
 
     def test_enforce_unique_labels(self):
         node1 = Node(label="node1")
@@ -284,6 +295,15 @@ class TestsEnergySystem:
 
         self.es.remove(subnetwork)
         assert not bool(self.es.nodes)
+
+    def test_removal_from_parent_nodes_subnodes_list(self):
+        subnetwork = Node(label="root")
+        self.es.add(subnetwork)
+        leaf1 = subnetwork.subnode(Node, local_name="leaf1")
+        assert leaf1 in subnetwork.subnodes
+
+        self.es.remove(leaf1)
+        assert leaf1 not in subnetwork.subnodes
 
     def test_add_populated_subnetwork(self):
         subnetwork = Node(label="root")

--- a/tests/test_energy_system.py
+++ b/tests/test_energy_system.py
@@ -276,6 +276,15 @@ class TestsEnergySystem:
 
         assert self.es.node[("leaf1", "root")] == leaf1
 
+    def test_automatically_remove_subnodes(self):
+        subnetwork = Node(label="root")
+        self.es.add(subnetwork)
+        subnetwork.subnode(Node, local_name="leaf1")
+        assert len(self.es.nodes) == 2
+
+        self.es.remove(subnetwork)
+        assert not bool(self.es.nodes)
+
     def test_add_populated_subnetwork(self):
         subnetwork = Node(label="root")
         leaf1 = subnetwork.subnode(Node, local_name="leaf1")


### PR DESCRIPTION
This PR introduces a `remove` function to the `EnergySystem` class that complements the existing `add` function - it removes nodes from the energy system.

I also took the liberty to open an Issue for that, where discussion is greatly welcome: https://github.com/oemof/oemof-network/issues/94